### PR TITLE
#25 Using '_' instead of '-' in role name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,62 +3,64 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
-## [Unreleased](https://github.com/idealista/prometheus_node_exporter-role/tree/develop)
-
-## [2.2.0](https://github.com/idealista/prometheus_node_exporter-role/tree/2.2.0)
+## [Unreleased](https://github.com/idealista/prometheus_node_exporter_role/tree/develop)
 ### Changed
-- *[#22](https://github.com/idealista/prometheus_node_exporter-role/issues/22) Add filefd collector by default* @jperera
+- *[#25](https://github.com/idealista/prometheus_node_exporter_role/issues/25) Using '_' instead of '-' in role name* @jperera
 
-## [2.1.0](https://github.com/idealista/prometheus_node_exporter-role/tree/2.1.0)
-[Full Changelog](https://github.com/idealista/prometheus_node_exporter-role/compare/2.0.0...2.1.0)
+## [2.2.0](https://github.com/idealista/prometheus_node_exporter_role/tree/2.2.0)
+### Changed
+- *[#22](https://github.com/idealista/prometheus_node_exporter_role/issues/22) Add filefd collector by default* @jperera
+
+## [2.1.0](https://github.com/idealista/prometheus_node_exporter_role/tree/2.1.0)
+[Full Changelog](https://github.com/idealista/prometheus_node_exporter_role/compare/2.0.0...2.1.0)
 ### Added
-- *[#20](https://github.com/idealista/prometheus_node_exporter-role/pull/20) Add node_exporter_manage_service toggle to control service management* @kostyrev
+- *[#20](https://github.com/idealista/prometheus_node_exporter_role/pull/20) Add node_exporter_manage_service toggle to control service management* @kostyrev
 
-## [2.0.0](https://github.com/idealista/prometheus_node_exporter-role/tree/2.0.0)
-[Full Changelog](https://github.com/idealista/prometheus_node_exporter-role/compare/1.2.6...2.0.0)
+## [2.0.0](https://github.com/idealista/prometheus_node_exporter_role/tree/2.0.0)
+[Full Changelog](https://github.com/idealista/prometheus_node_exporter_role/compare/1.2.6...2.0.0)
 ### Changed
-- *[#17](https://github.com/idealista/prometheus_node_exporter-role/issues/17) Update imports (deprecation warnings)* @jmonterrubio
+- *[#17](https://github.com/idealista/prometheus_node_exporter_role/issues/17) Update imports (deprecation warnings)* @jmonterrubio
 
-## [1.2.6](https://github.com/idealista/prometheus_node_exporter-role/tree/1.2.6)
-[Full Changelog](https://github.com/idealista/prometheus_node_exporter-role/compare/1.2.5...1.2.6)
+## [1.2.6](https://github.com/idealista/prometheus_node_exporter_role/tree/1.2.6)
+[Full Changelog](https://github.com/idealista/prometheus_node_exporter_role/compare/1.2.5...1.2.6)
 ### Fixed
-- *[#15](https://github.com/idealista/prometheus_node_exporter-role/pull/15) Explicitly set get_url dest file name* @mvollman
+- *[#15](https://github.com/idealista/prometheus_node_exporter_role/pull/15) Explicitly set get_url dest file name* @mvollman
 
-## [1.2.5](https://github.com/idealista/prometheus_node_exporter-role/tree/1.2.5)
-[Full Changelog](https://github.com/idealista/prometheus_node_exporter-role/compare/1.2.4...1.2.5)
+## [1.2.5](https://github.com/idealista/prometheus_node_exporter_role/tree/1.2.5)
+[Full Changelog](https://github.com/idealista/prometheus_node_exporter_role/compare/1.2.4...1.2.5)
 ### Fixed
-- *[#12](https://github.com/idealista/prometheus_node_exporter-role/issues/12) Group variable is not used when skeleton paths are created* @sorobon
+- *[#12](https://github.com/idealista/prometheus_node_exporter_role/issues/12) Group variable is not used when skeleton paths are created* @sorobon
 
-## [1.2.4](https://github.com/idealista/prometheus_node_exporter-role/tree/1.2.4)
-[Full Changelog](https://github.com/idealista/prometheus_node_exporter-role/compare/1.2.3...1.2.4)
+## [1.2.4](https://github.com/idealista/prometheus_node_exporter_role/tree/1.2.4)
+[Full Changelog](https://github.com/idealista/prometheus_node_exporter_role/compare/1.2.3...1.2.4)
 ### Fixed
-- *[#9](https://github.com/idealista/prometheus_node_exporter-role/issues/9) Fix PID logrotate check* @jmonterrubio
+- *[#9](https://github.com/idealista/prometheus_node_exporter_role/issues/9) Fix PID logrotate check* @jmonterrubio
 
 ### Added
 - *Add CI with Travis*
 
-## [1.2.3](https://github.com/idealista/prometheus_node_exporter-role/tree/1.2.3)
-[Full Changelog](https://github.com/idealista/prometheus_node_exporter-role/compare/1.2.2...1.2.3)
+## [1.2.3](https://github.com/idealista/prometheus_node_exporter_role/tree/1.2.3)
+[Full Changelog](https://github.com/idealista/prometheus_node_exporter_role/compare/1.2.2...1.2.3)
 ### Fixed
-- *[#5](https://github.com/idealista/prometheus_node_exporter-role/issues/5) Fix check version* @jmonterrubio
+- *[#5](https://github.com/idealista/prometheus_node_exporter_role/issues/5) Fix check version* @jmonterrubio
 
-## [1.2.2](https://github.com/idealista/prometheus_node_exporter-role/tree/1.2.2)
-[Full Changelog](https://github.com/idealista/prometheus_node_exporter-role/compare/1.2.1...1.2.2)
+## [1.2.2](https://github.com/idealista/prometheus_node_exporter_role/tree/1.2.2)
+[Full Changelog](https://github.com/idealista/prometheus_node_exporter_role/compare/1.2.1...1.2.2)
 ### Fixed
-- *[#2](https://github.com/idealista/prometheus_node_exporter-role/issues/2) Fix user shell* @jmonterrubio
+- *[#2](https://github.com/idealista/prometheus_node_exporter_role/issues/2) Fix user shell* @jmonterrubio
 
-## [1.2.1](https://github.com/idealista/prometheus_node_exporter-role/tree/1.2.1)
-[Full Changelog](https://github.com/idealista/prometheus_node_exporter-role/compare/1.2.0...1.2.1)
+## [1.2.1](https://github.com/idealista/prometheus_node_exporter_role/tree/1.2.1)
+[Full Changelog](https://github.com/idealista/prometheus_node_exporter_role/compare/1.2.0...1.2.1)
 ### Fixed
 - *Fix logrotate* @jmonterrubio
 
-## [1.2.0](https://github.com/idealista/prometheus_node_exporter-role/tree/1.2.0)
-[Full Changelog](https://github.com/idealista/prometheus_node_exporter-role/compare/1.1.1...1.2.0)
+## [1.2.0](https://github.com/idealista/prometheus_node_exporter_role/tree/1.2.0)
+[Full Changelog](https://github.com/idealista/prometheus_node_exporter_role/compare/1.1.1...1.2.0)
 ### Added
 - *[PLATFORM-295] Parametrizado de puerto y path*
 
-## [1.1.1](https://github.com/idealista/prometheus_node_exporter-role/tree/1.1.1)
-[Full Changelog](https://github.com/idealista/prometheus_node_exporter-role/compare/1.1.0...1.1.1)
+## [1.1.1](https://github.com/idealista/prometheus_node_exporter_role/tree/1.1.1)
+[Full Changelog](https://github.com/idealista/prometheus_node_exporter_role/compare/1.1.0...1.1.1)
 ### Added
 - *[PLATFORM-162] Cambiar los "collectors" activos por defecto y filtrar sus características, subir de versión node_exporter*
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ For testing purposes, [Molecule](https://molecule.readthedocs.io/) with [Vagrant
 Create or add to your roles dependency file (e.g requirements.yml):
 
 ```
-- src: idealista.prometheus_node_exporter-role
+- src: idealista.prometheus_node_exporter_role
   version: 1.0.0
   name: prometheus_node_exporter
 ```
@@ -67,7 +67,7 @@ molecule test
 
 ## Versioning
 
-For the versions available, see the [tags on this repository](https://github.com/idealista/prometheus_node_exporter-role/tags).
+For the versions available, see the [tags on this repository](https://github.com/idealista/prometheus_node_exporter_role/tags).
 
 Additionaly you can see what change in each version in the [CHANGELOG.md](CHANGELOG.md) file.
 
@@ -75,7 +75,7 @@ Additionaly you can see what change in each version in the [CHANGELOG.md](CHANGE
 
 * **Idealista** - *Work with* - [idealista](https://github.com/idealista)
 
-See also the list of [contributors](https://github.com/idealista/prometheus_node_exporter-role/contributors) who participated in this project.
+See also the list of [contributors](https://github.com/idealista/prometheus_node_exporter_role/contributors) who participated in this project.
 
 ## License
 

--- a/tests/playbook.yml
+++ b/tests/playbook.yml
@@ -1,7 +1,7 @@
 ---
 - hosts: all
   roles:
-    - prometheus_node_exporter-role
+    - prometheus_node_exporter_role
   post_tasks:
     - name: Ensure test packages
       apt:


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->


### Benefits

Coherence with role name requirements imposed by Ansible Galaxy (Both GitHub repo and Galaxy artifact has the same 'id').

### Possible Drawbacks

I don't know 😇

### Applicable Issuese? -->

### Applicable Issues

#25 