### PR TITLE
Add support for other architectures than amd64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased](https://github.com/idealista/prometheus_node_exporter_role/tree/develop)
+### Changed
+ - *[#46](https://github.com/idealista/prometheus_node_exporter_role/issues/46) Add support for other architectures than amd64*
 
 ## [5.0.0](https://github.com/idealista/prometheus_node_exporter_role/tree/5.0.0)
 [Full Changelog](https://github.com/idealista/prometheus_node_exporter_role/compare/4.1.0...5.0.0)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 ## General
 
 node_exporter_version: 0.18.1
-node_exporter_release_system: linux-amd64
+node_exporter_release_system: "linux-{{ node_exporter_arch }}"
 node_exporter_required_libs:
   - python-httplib2
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,17 +1,5 @@
 ---
 
-node_exporter_required_libs:
-  - python-httplib2
-
-node_exporter_release_name: "node_exporter-{{ node_exporter_version }}.{{ node_exporter_release_system }}"
-node_exporter_package: "node_exporter-{{ node_exporter_version }}.{{ node_exporter_release_system }}.tar.gz"
-node_exporter_url: "https://github.com/prometheus/node_exporter/releases/download/v{{ node_exporter_version }}/{{ node_exporter_package }}"
-
-_node_exporter_version_all: "{{ node_exporter_version.split('.') }}"
-_node_exporter_collectors_as_string_version: "{{ _node_exporter_version_all[0] | int == 0 and _node_exporter_version_all[1] | int < 15 }}"
-_node_exporter_command_version_check: "node_exporter {{ _node_exporter_collectors_as_string_version | ternary('-','--') }}version"
-_node_exporter_config_param_selector: --
-
 _node_exporter_arch_map:
   i386: '386'
   x86_64: 'amd64'

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -19,4 +19,4 @@ _node_exporter_arch_map:
   armv7l: 'armv7'
   armv6l: 'armv6'
 
-node_exporter_arch: "{{ _node_exporter_arch_map[ansible_architecture] | default(ansible_architecture) }}"
+node_exporter_arch: "{{ _node_exporter_arch_map[ansible_architecture] }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,22 @@
+---
+
+node_exporter_required_libs:
+  - python-httplib2
+
+node_exporter_release_name: "node_exporter-{{ node_exporter_version }}.{{ node_exporter_release_system }}"
+node_exporter_package: "node_exporter-{{ node_exporter_version }}.{{ node_exporter_release_system }}.tar.gz"
+node_exporter_url: "https://github.com/prometheus/node_exporter/releases/download/v{{ node_exporter_version }}/{{ node_exporter_package }}"
+
+_node_exporter_version_all: "{{ node_exporter_version.split('.') }}"
+_node_exporter_collectors_as_string_version: "{{ _node_exporter_version_all[0] | int == 0 and _node_exporter_version_all[1] | int < 15 }}"
+_node_exporter_command_version_check: "node_exporter {{ _node_exporter_collectors_as_string_version | ternary('-','--') }}version"
+_node_exporter_config_param_selector: --
+
+_node_exporter_arch_map:
+  i386: '386'
+  x86_64: 'amd64'
+  aarch64: 'arm64'
+  armv7l: 'armv7'
+  armv6l: 'armv6'
+
+node_exporter_arch: "{{ _node_exporter_arch_map[ansible_architecture] | default(ansible_architecture) }}"


### PR DESCRIPTION
### Requirements

### Description of the Change

This PR will add support for other architectures beside amd64.
It will map of architectures the `ansible_architecture` to the naming used by prometheus for their files.

### Benefits

- Add support for armv6/7/64, i386

### Possible Drawbacks

- None AFAIK

### Applicable Issues

None
