### PR TITLE
#62 Add support for Debian 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ env:
   jobs:
     - MOLECULE_DISTRO=debian:bullseye-slim
     - MOLECULE_DISTRO=debian:buster-slim
-    - MOLECULE_DISTRO=debian:stretch-slim
   global:
     - PY_COLOR=1
     - ANSIBLE_FORCE_COLOR=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,10 @@ install:
   - pipenv sync
 env:
   jobs:
+    - MOLECULE_DISTRO=debian:bullseye-slim
     - MOLECULE_DISTRO=debian:buster-slim
     - MOLECULE_DISTRO=debian:stretch-slim
+    - MOLECULE_DISTRO=debian:jessie-slim
   global:
     - PY_COLOR=1
     - ANSIBLE_FORCE_COLOR=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ env:
     - MOLECULE_DISTRO=debian:bullseye-slim
     - MOLECULE_DISTRO=debian:buster-slim
     - MOLECULE_DISTRO=debian:stretch-slim
-    - MOLECULE_DISTRO=debian:jessie-slim
   global:
     - PY_COLOR=1
     - ANSIBLE_FORCE_COLOR=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 ## [Unreleased](https://github.com/idealista/prometheus_node_exporter_role/tree/develop)
 ### Added
  - *[#62](https://github.com/idealista/prometheus_node_exporter_role/issues/62) Add support for Debian 11* @blalop
+### Changed
+ - *Drop Jessie support* @blalop
 
 ## [5.3.0](https://github.com/idealista/prometheus_node_exporter_role/tree/5.3.0)
 [Full Changelog](https://github.com/idealista/prometheus_node_exporter_role/compare/5.2.0...5.3.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased](https://github.com/idealista/prometheus_node_exporter_role/tree/develop)
+### Added
+ - *[#62](https://github.com/idealista/prometheus_node_exporter_role/issues/62) Add support for Debian 11* @blalop
 
 ## [5.3.0](https://github.com/idealista/prometheus_node_exporter_role/tree/5.3.0)
 [Full Changelog](https://github.com/idealista/prometheus_node_exporter_role/compare/5.2.0...5.3.0)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@
 node_exporter_version: 1.1.1
 node_exporter_release_system: "linux-{{ node_exporter_arch }}"
 node_exporter_required_libs:
-  - python-httplib2
+  - "{{ node_exporter_httplib2 }}"
 
 # Set true to force the download and installation of the binary
 node_exporter_force_reinstall: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,8 +3,6 @@
 
 node_exporter_version: 1.1.1
 node_exporter_release_system: "linux-{{ node_exporter_arch }}"
-node_exporter_required_libs:
-  - "{{ __node_exporter_httplib2 }}"
 
 # Set true to force the download and installation of the binary
 node_exporter_force_reinstall: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@
 node_exporter_version: 1.1.1
 node_exporter_release_system: "linux-{{ node_exporter_arch }}"
 node_exporter_required_libs:
-  - "{{ node_exporter_httplib2 }}"
+  - "{{ __node_exporter_httplib2 }}"
 
 # Set true to force the download and installation of the binary
 node_exporter_force_reinstall: false

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,5 +12,6 @@ galaxy_info:
         - jessie
         - stretch
         - buster
+        - bullseye
   galaxy_tags:
     - monitoring

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -9,7 +9,6 @@ galaxy_info:
   platforms:
     - name: Debian
       versions:
-        - jessie
         - stretch
         - buster
         - bullseye

--- a/molecule/default/Dockerfile.j2
+++ b/molecule/default/Dockerfile.j2
@@ -7,7 +7,12 @@ FROM {{ item.image }}
 {% endif %}
 
 # install minimal packages for debian slim images
+{% if item.image == 'debian:bullseye-slim' %}
+RUN apt-get update && \
+    apt-get install -y python3 sudo bash ca-certificates iproute2 systemd systemd-sysv python3-pip && \
+    apt-get clean
+{% else %}
 RUN apt-get update && \
     apt-get install -y python sudo bash ca-certificates iproute2 systemd systemd-sysv python-pip && \
     apt-get clean
-
+{% endif %}

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -10,7 +10,7 @@ platforms:
   - name: nodeexporter
     groups:
       - node_exporter
-    image: ${MOLECULE_DISTRO:-debian:buster-slim}
+    image: ${MOLECULE_DISTRO:-debian:bullseye-slim}
     privileged: false
     capabilities:
       - SYS_ADMIN

--- a/molecule/legacy_version/Dockerfile.j2
+++ b/molecule/legacy_version/Dockerfile.j2
@@ -7,7 +7,12 @@ FROM {{ item.image }}
 {% endif %}
 
 # install minimal packages for debian slim images
+{% if item.image == 'debian:bullseye-slim' %}
+RUN apt-get update && \
+    apt-get install -y python3 sudo bash ca-certificates iproute2 systemd systemd-sysv python3-pip && \
+    apt-get clean
+{% else %}
 RUN apt-get update && \
     apt-get install -y python sudo bash ca-certificates iproute2 systemd systemd-sysv python-pip && \
     apt-get clean
-
+{% endif %}

--- a/molecule/legacy_version/molecule.yml
+++ b/molecule/legacy_version/molecule.yml
@@ -11,7 +11,7 @@ platforms:
   - name: nodeexporter
     groups:
       - node_exporter
-    image: ${MOLECULE_DISTRO:-debian:buster-slim}
+    image: ${MOLECULE_DISTRO:-debian:bullseye-slim}
     privileged: false
     capabilities:
       - SYS_ADMIN

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,10 @@
 ---
 
+- name: NODE_EXPORTER | Gather OS specific vars
+  include_vars: "{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
+  tags:
+    - node_exporter_vars
+
 - name: NODE_EXPORTER | Install
   import_tasks: install.yml
   tags:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,11 @@
   tags:
     - node_exporter_vars
 
+- name: NODE EXPORTER | Define node_exporter_required_libs
+  set_fact:
+    node_exporter_required_libs: "{{ __node_exporter_required_libs }}"
+  when: node_exporter_required_libs is not defined
+
 - name: NODE_EXPORTER | Install
   import_tasks: install.yml
   tags:

--- a/vars/Debian-10.yml
+++ b/vars/Debian-10.yml
@@ -1,3 +1,3 @@
 ---
 
-node_exporter_httplib2: python-httplib2
+__node_exporter_httplib2: python-httplib2

--- a/vars/Debian-10.yml
+++ b/vars/Debian-10.yml
@@ -1,3 +1,4 @@
 ---
 
-__node_exporter_httplib2: python-httplib2
+__node_exporter_required_libs:
+  - python-httplib2

--- a/vars/Debian-10.yml
+++ b/vars/Debian-10.yml
@@ -1,0 +1,3 @@
+---
+
+node_exporter_httplib2: python-httplib2

--- a/vars/Debian-11.yml
+++ b/vars/Debian-11.yml
@@ -1,3 +1,4 @@
 ---
 
-__node_exporter_httplib2: python3-httplib2
+__node_exporter_required_libs:
+  - python3-httplib2

--- a/vars/Debian-11.yml
+++ b/vars/Debian-11.yml
@@ -1,3 +1,3 @@
 ---
 
-node_exporter_httplib2: python3-httplib2
+__node_exporter_httplib2: python3-httplib2

--- a/vars/Debian-11.yml
+++ b/vars/Debian-11.yml
@@ -1,0 +1,3 @@
+---
+
+node_exporter_httplib2: python3-httplib2

--- a/vars/Debian-8.yml
+++ b/vars/Debian-8.yml
@@ -1,3 +1,0 @@
----
-
-node_exporter_httplib2: python-httplib2

--- a/vars/Debian-8.yml
+++ b/vars/Debian-8.yml
@@ -1,0 +1,3 @@
+---
+
+node_exporter_httplib2: python-httplib2

--- a/vars/Debian-9.yml
+++ b/vars/Debian-9.yml
@@ -1,3 +1,3 @@
 ---
 
-node_exporter_httplib2: python-httplib2
+__node_exporter_httplib2: python-httplib2

--- a/vars/Debian-9.yml
+++ b/vars/Debian-9.yml
@@ -1,3 +1,4 @@
 ---
 
-__node_exporter_httplib2: python-httplib2
+__node_exporter_required_libs:
+  - python-httplib2

--- a/vars/Debian-9.yml
+++ b/vars/Debian-9.yml
@@ -1,0 +1,3 @@
+---
+
+node_exporter_httplib2: python-httplib2


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change

Add support for Debian 11.


### Benefits

Support for Debian 11.

### Possible Drawbacks

None, as older Debian versions are still supported.

### Applicable Issues

#62 
